### PR TITLE
Removed console log statement

### DIFF
--- a/src/com/koreez/particleeditorplugin/utils.js
+++ b/src/com/koreez/particleeditorplugin/utils.js
@@ -10,12 +10,6 @@ export const createImageFromBitmapData = (
   onerror,
   force = true,
 ) => {
-  console.log(
-    `createImageFromBitmapData ${key} | force : ${force} | cache : ${game.cache.checkImageKey(
-      key,
-    )}`,
-  )
-
   if (!force && game.cache.checkImageKey(key)) {
     onImageLoad(oncreate)
     return


### PR DESCRIPTION
Any way we could remove this console log statement? I use it a lot in my game testing and I'm getting a ton of these logs making it hard to parse my own. It seems to be the only log in the whole repo, so maybe its only left on accident?
  
You could also consider a npm package to handle this, or maybe it is possible with webpack/eslint? https://www.npmjs.com/package/remove-console-logs